### PR TITLE
Remove tarampampam/wrappers-php package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0']
         include:
           - php: '7.3'
             setup: basic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Minimal required PHP version now is `7.3`
+
+### Removed
+
+- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
+
 ## v2.4.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,13 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.0 || ~7.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0",
         "illuminate/config": "~6.0 || ~7.0 || ~8.0",
-        "tarampampam/wrappers-php": "^1.2 || ~2.0",
         "composer/package-versions-deprecated": "^1.11"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace AvtoDev\RabbitMqApiClient;
 
 use PackageVersions\Versions;
-use Tarampampam\Wrappers\Json;
 use GuzzleHttp\Client as GuzzleHttpClient;
 use GuzzleHttp\RequestOptions as GuzzleOptions;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
@@ -69,7 +68,9 @@ class Client implements ClientInterface
             ->getBody()
             ->getContents();
 
-        return (((array) Json::decode($contents))['status'] ?? null) === 'ok';
+        $contents = (array) \json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        return ($contents['status'] ?? null) === 'ok';
     }
 
     /**
@@ -84,7 +85,7 @@ class Client implements ClientInterface
             ->getBody()
             ->getContents();
 
-        return new QueueInfo((array) Json::decode($contents));
+        return new QueueInfo((array) \json_decode($contents, true, 512, JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace AvtoDev\RabbitMqApiClient;
 
 use GuzzleHttp\Exception\RequestException;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 interface ClientInterface
 {
@@ -24,7 +23,7 @@ interface ClientInterface
      * @param string|null $node_name
      *
      * @throws RequestException
-     * @throws JsonEncodeDecodeException
+     * @throws \JsonException
      *
      * @return bool
      */
@@ -37,7 +36,7 @@ interface ClientInterface
      * @param string $vhost
      *
      * @throws RequestException
-     * @throws JsonEncodeDecodeException
+     * @throws \JsonException
      *
      * @return QueueInfo
      */

--- a/src/QueueInfo.php
+++ b/src/QueueInfo.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace AvtoDev\RabbitMqApiClient;
 
-use Tarampampam\Wrappers\Json;
-
 class QueueInfo implements QueueInfoInterface
 {
     /**
@@ -76,7 +74,7 @@ class QueueInfo implements QueueInfoInterface
      */
     public function toJson($options = 0): string
     {
-        return Json::encode($this->raw_data, $options);
+        return (string) \json_encode($this->raw_data, $options);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -63,7 +63,7 @@ class ClientTest extends AbstractTestCase
     public function testPingSuccess(): void
     {
         $this->client->mock_handler->append(
-            new Response(200, ['content-type' => 'application/json'], json_encode([
+            new Response(200, ['content-type' => 'application/json'], \json_encode([
                 'status' => 'ok',
             ]))
         );
@@ -77,7 +77,7 @@ class ClientTest extends AbstractTestCase
     public function testPingFailed(): void
     {
         $this->client->mock_handler->append(
-            new Response(200, ['content-type' => 'application/json'], json_encode([
+            new Response(200, ['content-type' => 'application/json'], \json_encode([
                 'status' => 'failed',
                 'reason' => 'Something goes wrong',
             ]))

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,13 +6,11 @@ namespace AvtoDev\RabbitMqApiClient\Tests;
 
 use GuzzleHttp\Psr7\Response;
 use PackageVersions\Versions;
-use Tarampampam\Wrappers\Json;
 use AvtoDev\RabbitMqApiClient\Client;
 use AvtoDev\RabbitMqApiClient\QueueInfo;
 use GuzzleHttp\Exception\RequestException;
 use AvtoDev\RabbitMqApiClient\ClientInterface;
 use AvtoDev\RabbitMqApiClient\ConnectionSettings;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 /**
  * @covers \AvtoDev\RabbitMqApiClient\Client<extended>
@@ -65,7 +63,7 @@ class ClientTest extends AbstractTestCase
     public function testPingSuccess(): void
     {
         $this->client->mock_handler->append(
-            new Response(200, ['content-type' => 'application/json'], Json::encode([
+            new Response(200, ['content-type' => 'application/json'], json_encode([
                 'status' => 'ok',
             ]))
         );
@@ -79,7 +77,7 @@ class ClientTest extends AbstractTestCase
     public function testPingFailed(): void
     {
         $this->client->mock_handler->append(
-            new Response(200, ['content-type' => 'application/json'], Json::encode([
+            new Response(200, ['content-type' => 'application/json'], json_encode([
                 'status' => 'failed',
                 'reason' => 'Something goes wrong',
             ]))
@@ -93,7 +91,7 @@ class ClientTest extends AbstractTestCase
      */
     public function testPingWithWrongJsonResponse(): void
     {
-        $this->expectException(JsonEncodeDecodeException::class);
+        $this->expectException(\JsonException::class);
 
         $this->client->mock_handler->append(
             new Response(200, ['content-type' => 'application/json'], '{"status":"...')
@@ -134,7 +132,7 @@ class ClientTest extends AbstractTestCase
      */
     public function testQueueInfoWithWrongJsonResponse(): void
     {
-        $this->expectException(JsonEncodeDecodeException::class);
+        $this->expectException(\JsonException::class);
 
         $this->client->mock_handler->append(
             new Response(200, ['content-type' => 'application/json'], '{"data":"...')

--- a/tests/QueueInfoTest.php
+++ b/tests/QueueInfoTest.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace AvtoDev\RabbitMqApiClient\Tests;
 
 use Illuminate\Support\Str;
-use Tarampampam\Wrappers\Json;
 use AvtoDev\RabbitMqApiClient\QueueInfo;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -51,7 +50,7 @@ class QueueInfoTest extends AbstractTestCase
         $queue_info = new QueueInfo($input = ['foo' => 'bar']);
 
         $this->assertSame($input, $queue_info->toArray());
-        $this->assertSame(Json::encode($input), $queue_info->toJson());
+        $this->assertSame(\json_encode($input), $queue_info->toJson());
     }
 
     /**


### PR DESCRIPTION
## Description

### Changed

- Minimal required PHP version now is `7.3`

### Removed

- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
