### PR TITLE
Laravel 10&11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   php:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup, laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -21,15 +21,15 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
+        php: [ '8.1', '8.2', '8.3' ]
         include:
-          - php: '7.3'
-            setup: basic
+          - php: '8.1'
+            setup: [ basic, lowest ]
             coverage: no
-            laravel: '^7.0'
+            laravel: '^10.0'
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -39,12 +39,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -73,7 +73,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,10 +83,10 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Minimal require PHP version now is `8.1`
 - Minimal Laravel version now is `10.0`
-- Version of `composer` in docker container updated up to `2.7.4` 
+- Version of `composer` in docker container updated up to `2.7.4`
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support Laravel `10.x` and `11.x`
+
+### Changed
+
+- Minimal require PHP version now is `8.1`
+- Minimal Laravel version now is `10.0`
+- Version of `composer` in docker container updated up to `2.7.4` 
+
 ## v2.6.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM php:8.0-alpine
+FROM php:8.3-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.7.4 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
-    && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
+    && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.0.0 1>/dev/null \
+    && pecl install xdebug-3.3.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.0 || ~7.0",
-        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/config": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "guzzlehttp/guzzle": "^7.7",
+        "illuminate/contracts": "~10.0 || ~11.0",
+        "illuminate/support": "~10.0 || ~11.0",
+        "illuminate/config": "~10.0 || ~11.0",
         "composer/package-versions-deprecated": "^1.11"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "phpstan/phpstan": "^0.12.36",
-        "phpunit/phpunit": "^9.3"
+        "laravel/laravel": "~10.0 || ~11.0",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,36 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         forceCoversAnnotation="true"
-         stopOnFailure="false">
-
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage includeUncoveredFiles="false" processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <exclude>
-            <directory>./vendor</directory>
-            <directory>./tests</directory>
-        </exclude>
-        <report>
-            <clover outputFile="./coverage/clover.xml"/>
-            <html outputDirectory="./coverage/html"/>
-            <text outputFile="php://stdout" showUncoveredFiles="false"/>
-            <xml outputDirectory="./coverage/xml"/>
-        </report>
-    </coverage>
+         cacheDirectory=".phpunit.cache"
+         requireCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage includeUncoveredFiles="false">
+    <report>
+      <clover outputFile="./coverage/clover.xml"/>
+      <html outputDirectory="./coverage/html"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+      <xml outputDirectory="./coverage/xml"/>
+    </report>
+  </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+      <directory>./tests</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -91,13 +91,13 @@ class Client implements ClientInterface
     /**
      * HTTP client factory.
      *
-     * @param mixed ...$arguments
+     * @param array<string, mixed> $arguments
      *
      * @return GuzzleClientInterface
      */
-    protected function httpClientFactory(...$arguments): GuzzleClientInterface
+    protected function httpClientFactory(array $arguments): GuzzleClientInterface
     {
-        return new GuzzleHttpClient(...$arguments);
+        return new GuzzleHttpClient($arguments);
     }
 
     /**

--- a/src/Frameworks/Illuminate/ClientFactory.php
+++ b/src/Frameworks/Illuminate/ClientFactory.php
@@ -8,6 +8,7 @@ use AvtoDev\RabbitMqApiClient\Client;
 use AvtoDev\RabbitMqApiClient\ClientInterface;
 use AvtoDev\RabbitMqApiClient\ConnectionSettings;
 use Illuminate\Config\Repository as ConfigRepository;
+use AvtoDev\RabbitMqApiClient\ConnectionSettingsInterface;
 
 class ClientFactory implements ClientFactoryInterface
 {
@@ -45,7 +46,11 @@ class ClientFactory implements ClientFactoryInterface
      */
     public function defaultConnectionName(): string
     {
-        return (string) $this->config->get("{$this->config_root}.default");
+        $connection_name = $this->config->get("{$this->config_root}.default");
+
+        return \is_scalar($connection_name)
+            ? (string) $connection_name
+            : '';
     }
 
     /**
@@ -59,15 +64,25 @@ class ClientFactory implements ClientFactoryInterface
             throw new \InvalidArgumentException("Connection [$connection_name] does not exists.");
         }
 
-        $connection_options = $this->config->get("{$this->config_root}.connections.{$connection_name}");
+        /** @var array<string, mixed> $connection_options */
+        $connection_options = $this->config->get("{$this->config_root}.connections.{$connection_name}", []);
 
-        $settings = new ConnectionSettings(
-            $options[$entrypoint_key = 'entrypoint'] ?? $connection_options[$entrypoint_key],
-            $options[$login_key = 'login'] ?? $connection_options[$login_key],
-            $options[$password_key = 'password'] ?? $connection_options[$password_key],
-            $options[$timeout_key = 'timeout'] ?? $connection_options[$timeout_key] ?? 5,
-            $options[$user_agent_key = 'user_agent'] ?? $connection_options[$user_agent_key] ?? null
-        );
+        /** @var string $entrypoint */
+        $entrypoint = $options[$entrypoint_key = 'entrypoint'] ?? $connection_options[$entrypoint_key];
+
+        /** @var string $login */
+        $login = $options[$login_key = 'login'] ?? $connection_options[$login_key];
+
+        /** @var string $password */
+        $password = $options[$password_key = 'password'] ?? $connection_options[$password_key];
+
+        /** @var int $timeout */
+        $timeout = $options[$timeout_key = 'timeout'] ?? $connection_options[$timeout_key] ?? 5;
+
+        /** @var string|null $user_agent */
+        $user_agent = $options[$user_agent_key = 'user_agent'] ?? $connection_options[$user_agent_key] ?? null;
+
+        $settings = new ConnectionSettings($entrypoint, $login, $password, $timeout, $user_agent);
 
         return $this->clientFactory(
             $settings,
@@ -76,14 +91,13 @@ class ClientFactory implements ClientFactoryInterface
     }
 
     /**
-     * RabbitMQ client factory method.
-     *
-     * @param mixed ...$arguments
+     * @param ConnectionSettingsInterface $settings
+     * @param array<string, mixed> $guzzle_config
      *
      * @return ClientInterface
      */
-    protected function clientFactory(...$arguments): ClientInterface
+    protected function clientFactory(ConnectionSettingsInterface $settings, array $guzzle_config = []): ClientInterface
     {
-        return new Client(...$arguments);
+        return new Client($settings, $guzzle_config);
     }
 }

--- a/src/Frameworks/Illuminate/ClientFactory.php
+++ b/src/Frameworks/Illuminate/ClientFactory.php
@@ -76,8 +76,8 @@ class ClientFactory implements ClientFactoryInterface
         /** @var string $password */
         $password = $options[$password_key = 'password'] ?? $connection_options[$password_key];
 
-        /** @var int $timeout */
-        $timeout = $options[$timeout_key = 'timeout'] ?? $connection_options[$timeout_key] ?? 5;
+        $timeout_data = $options[$timeout_key = 'timeout'] ?? $connection_options[$timeout_key] ?? 5;
+        $timeout      = \is_numeric($timeout_data) ? \intval($timeout_data) : 5;
 
         /** @var string|null $user_agent */
         $user_agent = $options[$user_agent_key = 'user_agent'] ?? $connection_options[$user_agent_key] ?? null;

--- a/src/Frameworks/Illuminate/config/rabbitmq-api-client.php
+++ b/src/Frameworks/Illuminate/config/rabbitmq-api-client.php
@@ -28,7 +28,7 @@ return [
             'entrypoint' => env('RABBITMQ_API_ENTRYPOINT', 'http://127.0.0.1:15672'),
             'login'      => env('RABBITMQ_API_LOGIN', 'guest'),
             'password'   => env('RABBITMQ_API_PASSWORD', 'guest'),
-            'timeout'    => \is_numeric($timeout = env('RABBITMQ_API_TIMEOUT', 5)) ? \intval($timeout) : 5,
+            'timeout'    => env('RABBITMQ_API_TIMEOUT', 5),
             'user_agent' => env('RABBITMQ_API_USER_AGENT'),
             //'guzzle_config' => [], // Documentation: <http://docs.guzzlephp.org/en/latest/quickstart.html>
         ],

--- a/src/Frameworks/Illuminate/config/rabbitmq-api-client.php
+++ b/src/Frameworks/Illuminate/config/rabbitmq-api-client.php
@@ -28,7 +28,7 @@ return [
             'entrypoint' => env('RABBITMQ_API_ENTRYPOINT', 'http://127.0.0.1:15672'),
             'login'      => env('RABBITMQ_API_LOGIN', 'guest'),
             'password'   => env('RABBITMQ_API_PASSWORD', 'guest'),
-            'timeout'    => (int) env('RABBITMQ_API_TIMEOUT', 5),
+            'timeout'    => \is_numeric($timeout = env('RABBITMQ_API_TIMEOUT', 5)) ? \intval($timeout) : 5,
             'user_agent' => env('RABBITMQ_API_USER_AGENT'),
             //'guzzle_config' => [], // Documentation: <http://docs.guzzlephp.org/en/latest/quickstart.html>
         ],

--- a/src/QueueInfo.php
+++ b/src/QueueInfo.php
@@ -26,7 +26,9 @@ class QueueInfo implements QueueInfoInterface
      */
     public function getConsumersCount(): int
     {
-        return (int) ($this->raw_data['consumers'] ?? 0);
+        $consumers_count = $this->raw_data['consumers'] ?? 0;
+
+        return \is_numeric($consumers_count) ? \intval($consumers_count) : 0;
     }
 
     /**
@@ -34,7 +36,9 @@ class QueueInfo implements QueueInfoInterface
      */
     public function getMessagesCount(): int
     {
-        return (int) ($this->raw_data['messages'] ?? 0);
+        $message_count = $this->raw_data['messages'] ?? 0;
+
+        return \is_numeric($message_count) ? \intval($message_count) : 0;
     }
 
     /**
@@ -42,7 +46,9 @@ class QueueInfo implements QueueInfoInterface
      */
     public function getName(): ?string
     {
-        return $this->raw_data['name'] ?? null;
+        $name = $this->raw_data['name'] ?? null;
+
+        return \is_string($name) ? $name : null;
     }
 
     /**
@@ -50,7 +56,9 @@ class QueueInfo implements QueueInfoInterface
      */
     public function getNodeName(): ?string
     {
-        return $this->raw_data['node'] ?? null;
+        $node = $this->raw_data['node'] ?? null;
+
+        return \is_string($node) ? $node : null;
     }
 
     /**
@@ -58,7 +66,9 @@ class QueueInfo implements QueueInfoInterface
      */
     public function getState(): ?string
     {
-        return $this->raw_data['state'] ?? null;
+        $state = $this->raw_data['state'] ?? null;
+
+        return \is_string($state) ? $state : null;
     }
 
     /**
@@ -66,7 +76,9 @@ class QueueInfo implements QueueInfoInterface
      */
     public function getVhost(): ?string
     {
-        return $this->raw_data['vhost'] ?? null;
+        $vhost = $this->raw_data['vhost'] ?? null;
+
+        return \is_string($vhost) ? $vhost : null;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,7 +13,7 @@ use AvtoDev\RabbitMqApiClient\ClientInterface;
 use AvtoDev\RabbitMqApiClient\ConnectionSettings;
 
 /**
- * @covers \AvtoDev\RabbitMqApiClient\Client<extended>
+ * @covers \AvtoDev\RabbitMqApiClient\Client
  */
 class ClientTest extends AbstractTestCase
 {

--- a/tests/ConnectionSettingsTest.php
+++ b/tests/ConnectionSettingsTest.php
@@ -10,7 +10,7 @@ use AvtoDev\RabbitMqApiClient\ConnectionSettings;
 use AvtoDev\RabbitMqApiClient\ConnectionSettingsInterface;
 
 /**
- * @covers \AvtoDev\RabbitMqApiClient\ConnectionSettings<extended>
+ * @covers \AvtoDev\RabbitMqApiClient\ConnectionSettings
  */
 class ConnectionSettingsTest extends AbstractTestCase
 {

--- a/tests/Frameworks/Illuminate/ClientFactoryTest.php
+++ b/tests/Frameworks/Illuminate/ClientFactoryTest.php
@@ -14,7 +14,7 @@ use AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\ClientFactoryInterface;
 use AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\LaravelServiceProvider;
 
 /**
- * @covers \AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\ClientFactory<extended>
+ * @covers \AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\ClientFactory
  */
 class ClientFactoryTest extends AbstractLaravelTestCase
 {

--- a/tests/Frameworks/Illuminate/LaravelServiceProviderTest.php
+++ b/tests/Frameworks/Illuminate/LaravelServiceProviderTest.php
@@ -12,7 +12,7 @@ use AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\ClientFactoryInterface;
 use AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\LaravelServiceProvider;
 
 /**
- * @covers \AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\LaravelServiceProvider<extended>
+ * @covers \AvtoDev\RabbitMqApiClient\Frameworks\Illuminate\LaravelServiceProvider
  */
 class LaravelServiceProviderTest extends AbstractLaravelTestCase
 {

--- a/tests/QueueInfoTest.php
+++ b/tests/QueueInfoTest.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use AvtoDev\RabbitMqApiClient\QueueInfoInterface;
 
 /**
- * @covers \AvtoDev\RabbitMqApiClient\QueueInfo<extended>
+ * @covers \AvtoDev\RabbitMqApiClient\QueueInfo
  */
 class QueueInfoTest extends AbstractTestCase
 {


### PR DESCRIPTION
## Description

- Support Laravel `10.x` and `11.x`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Added

- Support Laravel `10.x` и `11.x`

### Changed

- Minimal require PHP version now is `8.1`
- Minimal Laravel version now is `10.0`
- Version of `composer` in docker container updated up to `2.7.4` 
